### PR TITLE
fix(ui): fix aria-control references

### DIFF
--- a/dist/react-apiembed.js
+++ b/dist/react-apiembed.js
@@ -1060,7 +1060,7 @@
 	                React.createElement(
 	                  "a",
 	                  {
-	                    "aria-controls": "#" + key,
+	                    "aria-controls": "" + key,
 	                    "aria-selected": "true",
 	                    role: "tab",
 	                    className: "tabs-component-tab-a",
@@ -1076,13 +1076,13 @@
 	          React.createElement(
 	            "div",
 	            { className: "tabs-component-panels" },
-	            this.props.snippets.filter(function (snippet, index) {
-	              return index == _this2.state.active;
-	            }).map(function (snippet) {
+	            this.props.snippets.map(function (snippet, index) {
+
+	              var activeTab = index == _this2.state.active;
 	              var key = _this2.getSnippetKey(snippet);
 	              return React.createElement(
 	                "section",
-	                { role: "tabpanel", id: "#" + key, key: "#" + key },
+	                { hidden: !activeTab, role: "tabpanel", id: "" + key, key: "#" + key },
 	                React.createElement(CodeSnippet, _extends({ har: _this2.props.har }, snippet))
 	              );
 	            })

--- a/src/CodeSnippetWidget.js
+++ b/src/CodeSnippetWidget.js
@@ -44,7 +44,7 @@ export default class CodeSnippetWidget extends React.Component {
                   key={index}
                 >
                   <a
-                    aria-controls={`#${key}`}
+                    aria-controls={`${key}`}
                     aria-selected="true"
                     role="tab"
                     className="tabs-component-tab-a"
@@ -60,13 +60,12 @@ export default class CodeSnippetWidget extends React.Component {
           </ul>
           <div className="tabs-component-panels">
             {this.props.snippets
-              .filter((snippet, index) => {
-                return index == this.state.active
-              })
-              .map(snippet => {
+              .map((snippet, index) => {
+
+                const activeTab = index == this.state.active;
                 const key = this.getSnippetKey(snippet)
                 return (
-                  <section role="tabpanel" id={`#${key}`} key={`#${key}`}>
+                  <section hidden={!activeTab} role="tabpanel" id={`${key}`} key={`#${key}`}>
                     <CodeSnippet har={this.props.har} {...snippet} />
                   </section>
                 )


### PR DESCRIPTION
Always render those divs so that the screen readers don't panic when they can't find an element with the proper id.