### PR TITLE
fix: refactor ids and keys for codesnippetwidget for a11y (TDX-1616) (TDX-1617)

### DIFF
--- a/dist/react-apiembed.js
+++ b/dist/react-apiembed.js
@@ -986,7 +986,7 @@
 
 	      return React.createElement(
 	        "pre",
-	        { className: "language-" + this.props.prismLanguage },
+	        { className: "language-" + this.props.prismLanguage, tabIndex: "0" },
 	        React.createElement("code", {
 	          className: "language-" + this.props.prismLanguage,
 	          dangerouslySetInnerHTML: codeHTML

--- a/dist/react-apiembed.js
+++ b/dist/react-apiembed.js
@@ -1015,21 +1015,28 @@
 
 	    _this.clickHandler = _this.clickHandler.bind(_this);
 	    _this.state = {
-	      active: 0
+	      activeTab: 0,
+	      active: props.har.method + props.har.url + 0
 	    };
 	    return _this;
 	  }
 
 	  createClass(CodeSnippetWidget, [{
+	    key: "componentDidUpdate",
+	    value: function componentDidUpdate(prevProps) {
+	      if (prevProps.har.url !== this.props.har.url) {
+	        this.setState({ active: this.props.har.method + this.props.har.url + this.state.activeTab });
+	      }
+	    }
+	  }, {
 	    key: "getSnippetKey",
 	    value: function getSnippetKey(snippet) {
 	      return "" + snippet.target + (snippet.client ? "-" + snippet.client : "");
 	    }
 	  }, {
 	    key: "clickHandler",
-	    value: function clickHandler(e) {
-	      e.preventDefault();
-	      this.setState({ active: e.target.id });
+	    value: function clickHandler(index) {
+	      this.setState({ active: this.props.har.method + this.props.har.url + index, activeTab: index });
 	    }
 	  }, {
 	    key: "render",
@@ -1038,6 +1045,8 @@
 
 	      var har = this.props.har;
 
+
+	      var uniqueId = har.method + har.url;
 
 	      return React.createElement(
 	        "div",
@@ -1054,19 +1063,21 @@
 	                "li",
 	                {
 	                  role: "presentation",
-	                  className: "tabs-component-tab" + (index == _this2.state.active ? " is-active" : ""),
+	                  className: "tabs-component-tab" + (uniqueId + index == _this2.state.active ? " is-active" : ""),
 	                  key: index
 	                },
 	                React.createElement(
 	                  "a",
 	                  {
-	                    "aria-controls": "" + key,
+	                    "aria-controls": "" + (key + uniqueId),
 	                    "aria-selected": "true",
 	                    role: "tab",
 	                    className: "tabs-component-tab-a",
-	                    id: index,
-	                    href: "#" + key,
-	                    onClick: _this2.clickHandler
+	                    id: uniqueId + index,
+	                    href: "#" + (key + uniqueId),
+	                    onClick: function onClick() {
+	                      return _this2.clickHandler(index);
+	                    }
 	                  },
 	                  snippet.target
 	                )
@@ -1077,13 +1088,12 @@
 	            "div",
 	            { className: "tabs-component-panels" },
 	            this.props.snippets.map(function (snippet, index) {
-
-	              var activeTab = index == _this2.state.active;
+	              var activeTab = uniqueId + index == _this2.state.active;
 	              var key = _this2.getSnippetKey(snippet);
 	              return React.createElement(
 	                "section",
-	                { hidden: !activeTab, role: "tabpanel", id: "" + key, key: "#" + key },
-	                React.createElement(CodeSnippet, _extends({ har: _this2.props.har }, snippet))
+	                { hidden: !activeTab, role: "tabpanel", id: "" + (key + uniqueId), key: index },
+	                React.createElement(CodeSnippet, _extends({ har: har }, snippet))
 	              );
 	            })
 	          )

--- a/dist/react-apiembed.js
+++ b/dist/react-apiembed.js
@@ -1025,7 +1025,7 @@
 	    key: "componentDidUpdate",
 	    value: function componentDidUpdate(prevProps) {
 	      if (prevProps.har.url !== this.props.har.url) {
-	        this.setState({ active: this.props.har.method + this.props.har.url + this.state.activeTab });
+	        this.setState({ active: this.getHarKey(this.props.har) + this.state.activeTab });
 	      }
 	    }
 	  }, {
@@ -1036,7 +1036,7 @@
 	  }, {
 	    key: "clickHandler",
 	    value: function clickHandler(index) {
-	      this.setState({ active: this.props.har.method + this.props.har.url + index, activeTab: index });
+	      this.setState({ active: this.getHarKey(this.props.har) + index, activeTab: index });
 	    }
 	  }, {
 	    key: "getHarKey",

--- a/dist/react-apiembed.js
+++ b/dist/react-apiembed.js
@@ -1039,6 +1039,11 @@
 	      this.setState({ active: this.props.har.method + this.props.har.url + index, activeTab: index });
 	    }
 	  }, {
+	    key: "getHarKey",
+	    value: function getHarKey(harObject) {
+	      return harObject.method + harObject.url;
+	    }
+	  }, {
 	    key: "render",
 	    value: function render() {
 	      var _this2 = this;
@@ -1046,7 +1051,7 @@
 	      var har = this.props.har;
 
 
-	      var uniqueId = har.method + har.url;
+	      var harKey = this.getHarKey(har);
 
 	      return React.createElement(
 	        "div",
@@ -1058,23 +1063,23 @@
 	            "ul",
 	            { role: "tablist", className: "tabs-component-tabs" },
 	            this.props.snippets.map(function (snippet, index) {
-	              var key = _this2.getSnippetKey(snippet);
+	              var snippetKey = _this2.getSnippetKey(snippet);
+
 	              return React.createElement(
 	                "li",
 	                {
 	                  role: "presentation",
-	                  className: "tabs-component-tab" + (uniqueId + index == _this2.state.active ? " is-active" : ""),
+	                  className: "tabs-component-tab" + (harKey + index == _this2.state.active ? " is-active" : ""),
 	                  key: index
 	                },
 	                React.createElement(
 	                  "a",
 	                  {
-	                    "aria-controls": "" + (key + uniqueId),
+	                    "aria-controls": "" + (snippetKey + harKey),
 	                    "aria-selected": "true",
 	                    role: "tab",
 	                    className: "tabs-component-tab-a",
-	                    id: uniqueId + index,
-	                    href: "#" + (key + uniqueId),
+	                    id: harKey + index,
 	                    onClick: function onClick() {
 	                      return _this2.clickHandler(index);
 	                    }
@@ -1088,11 +1093,12 @@
 	            "div",
 	            { className: "tabs-component-panels" },
 	            this.props.snippets.map(function (snippet, index) {
-	              var activeTab = uniqueId + index == _this2.state.active;
-	              var key = _this2.getSnippetKey(snippet);
+	              var activeTab = harKey + index == _this2.state.active;
+	              var snippetKey = _this2.getSnippetKey(snippet);
+
 	              return React.createElement(
 	                "section",
-	                { hidden: !activeTab, role: "tabpanel", id: "" + (key + uniqueId), key: index },
+	                { hidden: !activeTab, role: "tabpanel", id: "" + (snippetKey + harKey), key: index },
 	                React.createElement(CodeSnippet, _extends({ har: har }, snippet))
 	              );
 	            })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-apiembed",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "React api embed component.",
   "files": [
     "dist"

--- a/src/CodeSnippet.js
+++ b/src/CodeSnippet.js
@@ -37,7 +37,7 @@ export default class CodeSnippet extends React.Component {
     }
 
     return (
-      <pre className={`language-${this.props.prismLanguage}`}>
+      <pre className={`language-${this.props.prismLanguage}`} tabIndex="0">
         <code
           className={`language-${this.props.prismLanguage}`}
           dangerouslySetInnerHTML={codeHTML}

--- a/src/CodeSnippetWidget.js
+++ b/src/CodeSnippetWidget.js
@@ -20,7 +20,7 @@ export default class CodeSnippetWidget extends React.Component {
 
   componentDidUpdate(prevProps) {
     if (prevProps.har.url !== this.props.har.url) {
-      this.setState({ active: this.props.har.method + this.props.har.url + this.state.activeTab})
+      this.setState({ active: this.getHarKey(this.props.har) + this.state.activeTab})
     }
   }
 
@@ -29,7 +29,7 @@ export default class CodeSnippetWidget extends React.Component {
   }
 
   clickHandler(index) {
-    this.setState({ active: this.props.har.method + this.props.har.url + index, activeTab: index })
+    this.setState({ active: this.getHarKey(this.props.har) + index, activeTab: index })
   }
 
   getHarKey(harObject) {

--- a/src/CodeSnippetWidget.js
+++ b/src/CodeSnippetWidget.js
@@ -13,7 +13,14 @@ export default class CodeSnippetWidget extends React.Component {
     super(props)
     this.clickHandler = this.clickHandler.bind(this)
     this.state = {
-      active: 0
+      activeTab: 0,
+      active: props.har.method + props.har.url + 0
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    if (prevProps.har.url !== this.props.har.url) {
+      this.setState({ active: this.props.har.method + this.props.har.url + this.state.activeTab})
     }
   }
 
@@ -21,13 +28,14 @@ export default class CodeSnippetWidget extends React.Component {
     return `${snippet.target}${snippet.client ? `-${snippet.client}` : ""}`
   }
 
-  clickHandler(e) {
-    e.preventDefault()
-    this.setState({ active: e.target.id })
+  clickHandler(index) {
+    this.setState({ active: this.props.har.method + this.props.har.url + index, activeTab: index })
   }
 
   render() {
     const { har } = this.props
+
+    const uniqueId = har.method + har.url
 
     return (
       <div className="tabs-component">
@@ -39,18 +47,18 @@ export default class CodeSnippetWidget extends React.Component {
                 <li
                   role="presentation"
                   className={
-                    "tabs-component-tab" + (index == this.state.active ? " is-active" : "")
+                    "tabs-component-tab" + ((uniqueId + index) == this.state.active ? " is-active" : "")
                   }
                   key={index}
                 >
                   <a
-                    aria-controls={`${key}`}
+                    aria-controls={`${key + uniqueId}`}
                     aria-selected="true"
                     role="tab"
                     className="tabs-component-tab-a"
-                    id={index}
-                    href={`#${key}`}
-                    onClick={this.clickHandler}
+                    id={uniqueId + index}
+                    href={`#${key + uniqueId}`}
+                    onClick={() => this.clickHandler(index)}
                   >
                     {snippet.target}
                   </a>
@@ -61,12 +69,11 @@ export default class CodeSnippetWidget extends React.Component {
           <div className="tabs-component-panels">
             {this.props.snippets
               .map((snippet, index) => {
-
-                const activeTab = index == this.state.active;
+                const activeTab = (uniqueId + index) == this.state.active;
                 const key = this.getSnippetKey(snippet)
                 return (
-                  <section hidden={!activeTab} role="tabpanel" id={`${key}`} key={`#${key}`}>
-                    <CodeSnippet har={this.props.har} {...snippet} />
+                  <section hidden={!activeTab} role="tabpanel" id={`${key + uniqueId}`} key={index}>
+                    <CodeSnippet har={har} {...snippet} />
                   </section>
                 )
               })}

--- a/src/CodeSnippetWidget.js
+++ b/src/CodeSnippetWidget.js
@@ -32,32 +32,36 @@ export default class CodeSnippetWidget extends React.Component {
     this.setState({ active: this.props.har.method + this.props.har.url + index, activeTab: index })
   }
 
+  getHarKey(harObject) {
+    return harObject.method + harObject.url
+  }
+
   render() {
     const { har } = this.props
 
-    const uniqueId = har.method + har.url
+    const harKey = this.getHarKey(har);
 
     return (
       <div className="tabs-component">
         <div className="tabs-component-body">
           <ul role="tablist" className="tabs-component-tabs">
             {this.props.snippets.map((snippet, index) => {
-              const key = this.getSnippetKey(snippet)
+              const snippetKey = this.getSnippetKey(snippet)
+
               return (
                 <li
                   role="presentation"
                   className={
-                    "tabs-component-tab" + ((uniqueId + index) == this.state.active ? " is-active" : "")
+                    "tabs-component-tab" + ((harKey + index) == this.state.active ? " is-active" : "")
                   }
                   key={index}
                 >
                   <a
-                    aria-controls={`${key + uniqueId}`}
+                    aria-controls={`${snippetKey + harKey}`}
                     aria-selected="true"
                     role="tab"
                     className="tabs-component-tab-a"
-                    id={uniqueId + index}
-                    href={`#${key + uniqueId}`}
+                    id={harKey + index}
                     onClick={() => this.clickHandler(index)}
                   >
                     {snippet.target}
@@ -69,10 +73,11 @@ export default class CodeSnippetWidget extends React.Component {
           <div className="tabs-component-panels">
             {this.props.snippets
               .map((snippet, index) => {
-                const activeTab = (uniqueId + index) == this.state.active;
-                const key = this.getSnippetKey(snippet)
+                const activeTab = (harKey + index) == this.state.active;
+                const snippetKey = this.getSnippetKey(snippet)
+
                 return (
-                  <section hidden={!activeTab} role="tabpanel" id={`${key + uniqueId}`} key={index}>
+                  <section hidden={!activeTab} role="tabpanel" id={`${snippetKey + harKey}`} key={index}>
                     <CodeSnippet har={har} {...snippet} />
                   </section>
                 )


### PR DESCRIPTION
This fixes the two accessibility errors relating to non-unique IDs. 

- Using the `har.method` and `har.url` to differentiate between the IDs on the tabs when we have multiple `CodeSnippetWidget`s on one page.


For testing locally 
- `swagger-ui-kong-theme` consumes this package, so pull this repo and link them via `yarn link`
- Build `swagger-ui-kong-theme`
- Change `spec-renderer.html` in `kong-portal-templates` to match the commit hash from the above build.

[sample-technical-specifications.zip](https://github.com/Kong/react-apiembed/files/7488821/sample-technical-specifications.zip)

- `retirement-bereavement-care-address-lookup-location-service-v1.yaml` and `service-award-substitute-PIP-Service-Award-Substitute-v1` were throwing the a11y issues before regarding non-unique IDs - should no longer be coming up and everything should work as it did before.
