### PR TITLE
feat: add keyboard interactivity to tabs in CodeSnippetWidget

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -49,6 +49,7 @@
   .tabs-component-tab {
     margin-right: .5em;
     transition: transform .3s ease;
+    cursor: pointer;
   }
 
   .tabs-component-tab-a {

--- a/docs/iframe.html
+++ b/docs/iframe.html
@@ -67,6 +67,7 @@
   .tabs-component-tab {
     margin-right: .5em;
     transition: transform .3s ease;
+    cursor: pointer;
   }
 
   .tabs-component-tab-a {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-apiembed",
-  "version": "0.1.5",
+  "version": "0.1.4",
   "description": "React api embed component.",
   "files": [
     "dist"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-apiembed",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "React api embed component.",
   "files": [
     "dist"

--- a/src/CodeSnippetWidget.js
+++ b/src/CodeSnippetWidget.js
@@ -12,15 +12,21 @@ export default class CodeSnippetWidget extends React.Component {
   constructor(props) {
     super(props)
     this.clickHandler = this.clickHandler.bind(this)
+    this.keypressHandler = this.keypressHandler.bind(this)
     this.state = {
       activeTab: 0,
       active: props.har.method + props.har.url + 0
     }
+    this.tabRefs = Array.from({length: this.props.snippets.length}, () => React.createRef());
   }
 
-  componentDidUpdate(prevProps) {
+  componentDidUpdate(prevProps, prevState) {
     if (prevProps.har.url !== this.props.har.url) {
       this.setState({ active: this.getHarKey(this.props.har) + this.state.activeTab})
+    }
+
+    if (prevState.activeTab !== this.state.activeTab) {
+      this.tabRefs[this.state.activeTab].current.focus()
     }
   }
 
@@ -30,6 +36,26 @@ export default class CodeSnippetWidget extends React.Component {
 
   clickHandler(index) {
     this.setState({ active: this.getHarKey(this.props.har) + index, activeTab: index })
+  }
+
+  keypressHandler(key, index) {
+    let targetIndex = index
+    const lastIndex = this.props.snippets.length - 1
+
+    if (key === "ArrowUp" || key === "ArrowLeft") {
+      if (index === 0) {
+        targetIndex = lastIndex
+      } else {
+        targetIndex = index - 1
+      }
+    } else if (key === "ArrowRight" || key === "ArrowDown") {
+      if (index === lastIndex) {
+        targetIndex = 0
+      } else {
+        targetIndex = index + 1
+      }
+    }
+    this.setState({ active: this.getHarKey(this.props.har) + targetIndex, activeTab: targetIndex })
   }
 
   getHarKey(harObject) {
@@ -50,23 +76,26 @@ export default class CodeSnippetWidget extends React.Component {
 
               return (
                 <li
-                  role="presentation"
+                  role="tab"
                   className={
                     "tabs-component-tab" + ((harKey + index) == this.state.active ? " is-active" : "")
                   }
+                  aria-controls={`${snippetKey + harKey}`}
+                  onKeyUp={(e) => this.keypressHandler(e.nativeEvent.code, index)}
+                  onClick={() => this.clickHandler(index)}
+                  aria-selected={(harKey + index) == this.state.active}
+                  tabIndex={(harKey + index) == this.state.active ? 0 : -1}
+                  ref={el => this.tabRefs[index].current = el}
                   key={index}
                 >
-                  <a
-                    aria-controls={`${snippetKey + harKey}`}
-                    aria-selected="true"
-                    role="tab"
+                  <span
+                    role="presentation"
                     className="tabs-component-tab-a"
                     id={harKey + index}
-                    onClick={() => this.clickHandler(index)}
                   >
                     {snippet.target}
                     {snippet.client && ` - ${snippet.client}`}
-                  </a>
+                  </span>
                 </li>
               )
             })}

--- a/src/CodeSnippetWidget.js
+++ b/src/CodeSnippetWidget.js
@@ -88,14 +88,14 @@ export default class CodeSnippetWidget extends React.Component {
                   ref={el => this.tabRefs[index].current = el}
                   key={index}
                 >
-                  <span
+                  <a
                     role="presentation"
                     className="tabs-component-tab-a"
                     id={harKey + index}
                   >
                     {snippet.target}
                     {snippet.client && ` - ${snippet.client}`}
-                  </span>
+                  </a>
                 </li>
               )
             })}


### PR DESCRIPTION
This PR introduces interactivity to the tabs in `CodeSnippetWidget`, as well as some a11y improvements. The interactivity follows the guide in https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/tablist_role - meaning that:
- Left/Up arrows will move to the previous tab
- Right/Down arrows will move to the next tab
- If they are at the end, next will go to the beginning. If they are at the beginning, previous will go to the end.