### PR TITLE
feat(snippet) add prop to showClientInTab

### DIFF
--- a/src/CodeSnippet.js
+++ b/src/CodeSnippet.js
@@ -51,5 +51,6 @@ CodeSnippet.propTypes = {
   har: PropTypes.object.isRequired,
   target: PropTypes.string.isRequired,
   client: PropTypes.string,
+  showClientInTab: PropTypes.boolean,
   prismLanguage: PropTypes.string.isRequired
 }

--- a/src/CodeSnippetWidget.js
+++ b/src/CodeSnippetWidget.js
@@ -65,7 +65,7 @@ export default class CodeSnippetWidget extends React.Component {
                     onClick={() => this.clickHandler(index)}
                   >
                     {snippet.target}
-                    {snippet.client && ` - ${snippet.client}`}
+                    {snippet.client && snippet.showClientInTab && ` - ${snippet.client}`}
                   </a>
                 </li>
               )

--- a/stories/index.stories.js
+++ b/stories/index.stories.js
@@ -105,4 +105,22 @@ storiesOf("CodeSnippetWidget", module).add("one language", () => (
       },
     ]}
   />
+)).add("showClientInTab", () => (
+  <CodeSnippetWidget
+    har={exampleHAR}
+    snippets={[
+      {
+        prismLanguage: "javascript",
+        target: "javascript",
+        client: "jquery",
+        showClientInTab: true
+      },
+      {
+        prismLanguage: "bash",
+        target: "shell",
+        client: "curl",
+        showClientInTab: true
+      },
+    ]}
+  />
 ))


### PR DESCRIPTION
This adds a prop `showClientInTab` to optionally render the `client` prop along with the `target` prop in the tab, like `target - client`.

This modifies the behavior from https://github.com/Kong/react-apiembed/pull/14 so that it is opt-in, as we don't want this feature to interfere with existing users' expectations.

cc @grzegorzxpatyk