### PR TITLE
refactor: refactor tab refs for backwaRds compatibility

### DIFF
--- a/dist/react-apiembed.js
+++ b/dist/react-apiembed.js
@@ -1014,15 +1014,17 @@
 
 	    var _this = possibleConstructorReturn(this, (CodeSnippetWidget.__proto__ || Object.getPrototypeOf(CodeSnippetWidget)).call(this, props));
 
+	    _this.setTabRef = function (element, index) {
+	      _this.tabRefs[index] = element;
+	    };
+
 	    _this.clickHandler = _this.clickHandler.bind(_this);
 	    _this.keypressHandler = _this.keypressHandler.bind(_this);
 	    _this.state = {
 	      activeTab: 0,
 	      active: props.har.method + props.har.url + 0
 	    };
-	    _this.tabRefs = Array.from({ length: _this.props.snippets.length }, function () {
-	      return React.createRef();
-	    });
+	    _this.tabRefs = [];
 	    return _this;
 	  }
 
@@ -1034,7 +1036,7 @@
 	      }
 
 	      if (prevState.activeTab !== this.state.activeTab) {
-	        this.tabRefs[this.state.activeTab].current.focus();
+	        this.tabRefs[this.state.activeTab].focus();
 	      }
 	    }
 	  }, {
@@ -1110,7 +1112,7 @@
 	                  "aria-selected": harKey + index == _this2.state.active,
 	                  tabIndex: harKey + index == _this2.state.active ? 0 : -1,
 	                  ref: function ref(el) {
-	                    return _this2.tabRefs[index].current = el;
+	                    return _this2.setTabRef(el, index);
 	                  },
 	                  key: index
 	                },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-apiembed",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "React api embed component.",
   "files": [
     "dist"

--- a/src/CodeSnippetWidget.js
+++ b/src/CodeSnippetWidget.js
@@ -17,7 +17,7 @@ export default class CodeSnippetWidget extends React.Component {
       activeTab: 0,
       active: props.har.method + props.har.url + 0
     }
-    this.tabRefs = Array.from({length: this.props.snippets.length}, () => React.createRef());
+    this.tabRefs = [];
   }
 
   componentDidUpdate(prevProps, prevState) {
@@ -26,9 +26,13 @@ export default class CodeSnippetWidget extends React.Component {
     }
 
     if (prevState.activeTab !== this.state.activeTab) {
-      this.tabRefs[this.state.activeTab].current.focus()
+      this.tabRefs[this.state.activeTab].focus()
     }
   }
+
+  setTabRef = (element, index) => {
+    this.tabRefs[index] = element;
+  };
 
   getSnippetKey(snippet) {
     return `${snippet.target}${snippet.client ? `-${snippet.client}` : ""}`
@@ -85,7 +89,7 @@ export default class CodeSnippetWidget extends React.Component {
                   onClick={() => this.clickHandler(index)}
                   aria-selected={(harKey + index) == this.state.active}
                   tabIndex={(harKey + index) == this.state.active ? 0 : -1}
-                  ref={el => this.tabRefs[index].current = el}
+                  ref={el => this.setTabRef(el, index)}
                   key={index}
                 >
                   <a


### PR DESCRIPTION
`createRef` isn't available in versions <16.3 - this improves backwards compatibility since callback refs are compatible with versions below that.