### PR TITLE
fix: read out snippet content

### DIFF
--- a/dist/react-apiembed.js
+++ b/dist/react-apiembed.js
@@ -981,12 +981,12 @@
 
 	      var code = new HTTPSnippet(har).convert(target, client);
 	      var codeHTML = {
-	        __html: prism.highlight(code, prism.languages[prismLanguage], prismLanguage)
+	        __html: "<div tabindex=\"0\">" + prism.highlight(code, prism.languages[prismLanguage], prismLanguage).replaceAll('<span', '<span role="text"') + "</div>"
 	      };
 
 	      return React.createElement(
 	        "pre",
-	        { className: "language-" + this.props.prismLanguage, tabIndex: "0" },
+	        { className: "language-" + this.props.prismLanguage },
 	        React.createElement("code", {
 	          className: "language-" + this.props.prismLanguage,
 	          dangerouslySetInnerHTML: codeHTML

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-apiembed",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "React api embed component.",
   "files": [
     "dist"

--- a/src/CodeSnippet.js
+++ b/src/CodeSnippet.js
@@ -33,11 +33,11 @@ export default class CodeSnippet extends React.Component {
 
     const code = new HTTPSnippet(har).convert(target, client)
     const codeHTML = {
-      __html: Prism.highlight(code, Prism.languages[prismLanguage], prismLanguage)
+      __html: `<div tabindex="0">${Prism.highlight(code, Prism.languages[prismLanguage], prismLanguage).replaceAll('<span', '<span role="text"')}</div>`
     }
 
     return (
-      <pre className={`language-${this.props.prismLanguage}`} tabIndex="0">
+      <pre className={`language-${this.props.prismLanguage}`}>
         <code
           className={`language-${this.props.prismLanguage}`}
           dangerouslySetInnerHTML={codeHTML}


### PR DESCRIPTION
This change updates the `CodeSnippetWidget` to be more accessible, and reading out the content of each snippet. This was done by wrapping the content of the `code` tag in a div, and then adding `role="text"` to each span.

<img width="808" alt="Screen Shot 2022-08-11 at 5 55 57 PM" src="https://user-images.githubusercontent.com/40131297/184263693-39405e2b-456b-46ab-9809-4fbab1bc218b.png">
