### PR TITLE
chore: add more keyboard functionality for codesnippet

### DIFF
--- a/src/CodeSnippet.js
+++ b/src/CodeSnippet.js
@@ -25,7 +25,7 @@ export default class CodeSnippet extends React.Component {
   }
 
   render() {
-    let { har, target, client, prismLanguage } = this.props
+    let { har, target, client, prismLanguage, tabIndex, passedRef, keypressHandler } = this.props
     // loadLanguages([prismLanguage])
 
     // TODO: httpsnippet should expose isLanguageSupported() method
@@ -33,15 +33,14 @@ export default class CodeSnippet extends React.Component {
 
     const code = new HTTPSnippet(har).convert(target, client)
     const codeHTML = {
-      __html: `<div tabindex="0">${Prism.highlight(code, Prism.languages[prismLanguage], prismLanguage).replaceAll('<span', '<span role="text"')}</div>`
+      __html: `${Prism.highlight(code, Prism.languages[prismLanguage], prismLanguage).replaceAll('<span', '<span role="text"')}`
     }
 
     return (
-      <pre className={`language-${this.props.prismLanguage}`}>
-        <code
-          className={`language-${this.props.prismLanguage}`}
-          dangerouslySetInnerHTML={codeHTML}
-        />
+      <pre className={`language-${this.props.prismLanguage}`} onKeyDown={keypressHandler}>
+        <code className={`language-${this.props.prismLanguage}`}>
+          <div ref={passedRef} tabIndex={tabIndex} dangerouslySetInnerHTML={codeHTML} />
+        </code>
       </pre>
     )
   }
@@ -51,6 +50,9 @@ CodeSnippet.propTypes = {
   har: PropTypes.object.isRequired,
   target: PropTypes.string.isRequired,
   client: PropTypes.string,
-  showClientInTab: PropTypes.boolean,
-  prismLanguage: PropTypes.string.isRequired
+  showClientInTab: PropTypes.bool,
+  prismLanguage: PropTypes.string.isRequired,
+  tabIndex: PropTypes.number,
+  passedRef: PropTypes.func,
+  keypressHandler: PropTypes.func
 }

--- a/src/CodeSnippet.js
+++ b/src/CodeSnippet.js
@@ -38,8 +38,8 @@ export default class CodeSnippet extends React.Component {
 
     return (
       <pre className={`language-${this.props.prismLanguage}`} onKeyDown={keypressHandler}>
-        <code ref={passedRef} className={`language-${this.props.prismLanguage}`}>
-          <div tabIndex={tabIndex} dangerouslySetInnerHTML={codeHTML} />
+        <code className={`language-${this.props.prismLanguage}`}>
+          <div ref={passedRef} tabIndex={tabIndex} dangerouslySetInnerHTML={codeHTML} />
         </code>
       </pre>
     )

--- a/src/CodeSnippet.js
+++ b/src/CodeSnippet.js
@@ -38,8 +38,8 @@ export default class CodeSnippet extends React.Component {
 
     return (
       <pre className={`language-${this.props.prismLanguage}`} onKeyDown={keypressHandler}>
-        <code className={`language-${this.props.prismLanguage}`}>
-          <div ref={passedRef} tabIndex={tabIndex} dangerouslySetInnerHTML={codeHTML} />
+        <code ref={passedRef} className={`language-${this.props.prismLanguage}`}>
+          <div tabIndex={tabIndex} dangerouslySetInnerHTML={codeHTML} />
         </code>
       </pre>
     )

--- a/src/CodeSnippetWidget.js
+++ b/src/CodeSnippetWidget.js
@@ -47,7 +47,7 @@ export default class CodeSnippetWidget extends React.Component {
     this.setState({ active: this.getHarKey(this.props.har) + index, activeTab: index })
   }
 
-  keypressHandler(key, index) {
+  keypressHandler(key, index, event) {
     let targetIndex = index
     const lastIndex = this.props.snippets.length - 1
 
@@ -65,6 +65,11 @@ export default class CodeSnippetWidget extends React.Component {
       }
     } else if (key === "Enter") {
       this.contentRefs[this.state.activeTab].focus()
+    } else if (key === "Tab" && event.shiftKey) {
+      if (index !== 0) {
+        event.preventDefault()
+        this.contentRefs[this.state.activeTab].focus()
+      }
     }
     this.setState({ active: this.getHarKey(this.props.har) + targetIndex, activeTab: targetIndex })
   }
@@ -76,10 +81,16 @@ export default class CodeSnippetWidget extends React.Component {
     
     if (key === "Tab" && !event.shiftKey) {
       if (index !== lastIndex) {
+        event.preventDefault()
         targetIndex = index + 1
-        this.setState({ active: this.getHarKey(this.props.har) + targetIndex, activeTab: targetIndex })
+      }
+    } else if (key === "Tab" && event.shiftKey) {
+      if (index !== 0) {
+        event.preventDefault()
+        targetIndex = index - 1
       }
     }
+    this.setState({ active: this.getHarKey(this.props.har) + targetIndex, activeTab: targetIndex })
   }
 
   getHarKey(harObject) {
@@ -105,7 +116,7 @@ export default class CodeSnippetWidget extends React.Component {
                     "tabs-component-tab" + ((harKey + index) == this.state.active ? " is-active" : "")
                   }
                   aria-controls={`${snippetKey + harKey}`}
-                  onKeyDown={(e) => this.keypressHandler(e.nativeEvent.code, index)}
+                  onKeyDown={(e) => this.keypressHandler(e.nativeEvent.code, index, e)}
                   onClick={() => this.clickHandler(index)}
                   aria-selected={(harKey + index) == this.state.active}
                   tabIndex={(harKey + index) == this.state.active ? 0 : -1}

--- a/src/CodeSnippetWidget.js
+++ b/src/CodeSnippetWidget.js
@@ -18,6 +18,7 @@ export default class CodeSnippetWidget extends React.Component {
       active: props.har.method + props.har.url + 0
     }
     this.tabRefs = [];
+    this.contentRefs = [];
   }
 
   componentDidUpdate(prevProps, prevState) {
@@ -33,6 +34,10 @@ export default class CodeSnippetWidget extends React.Component {
   setTabRef = (element, index) => {
     this.tabRefs[index] = element;
   };
+
+  setContentRef = (element, index) => {
+    this.contentRefs[index] = element
+  }
 
   getSnippetKey(snippet) {
     return `${snippet.target}${snippet.client ? `-${snippet.client}` : ""}`
@@ -58,8 +63,23 @@ export default class CodeSnippetWidget extends React.Component {
       } else {
         targetIndex = index + 1
       }
+    } else if (key === "Enter") {
+      this.contentRefs[this.state.activeTab].focus()
     }
     this.setState({ active: this.getHarKey(this.props.har) + targetIndex, activeTab: targetIndex })
+  }
+
+  contentKeypressHandler(key, index, event) {
+    let targetIndex = index
+    const lastIndex = this.props.snippets.length - 1
+
+    
+    if (key === "Tab" && !event.shiftKey) {
+      if (index !== lastIndex) {
+        targetIndex = index + 1
+        this.setState({ active: this.getHarKey(this.props.har) + targetIndex, activeTab: targetIndex })
+      }
+    }
   }
 
   getHarKey(harObject) {
@@ -85,7 +105,7 @@ export default class CodeSnippetWidget extends React.Component {
                     "tabs-component-tab" + ((harKey + index) == this.state.active ? " is-active" : "")
                   }
                   aria-controls={`${snippetKey + harKey}`}
-                  onKeyUp={(e) => this.keypressHandler(e.nativeEvent.code, index)}
+                  onKeyDown={(e) => this.keypressHandler(e.nativeEvent.code, index)}
                   onClick={() => this.clickHandler(index)}
                   aria-selected={(harKey + index) == this.state.active}
                   tabIndex={(harKey + index) == this.state.active ? 0 : -1}
@@ -111,8 +131,19 @@ export default class CodeSnippetWidget extends React.Component {
                 const snippetKey = this.getSnippetKey(snippet)
 
                 return (
-                  <section hidden={!activeTab} role="tabpanel" id={`${snippetKey + harKey}`} key={index}>
-                    <CodeSnippet har={har} {...snippet} />
+                  <section 
+                    hidden={!activeTab}
+                    role="tabpanel"
+                    id={`${snippetKey + harKey}`}
+                    key={index}
+                  >
+                    <CodeSnippet
+                      tabIndex={activeTab ? 0 : -1}
+                      har={har}
+                      passedRef={el => this.setContentRef(el, index)}
+                      keypressHandler={(e) => this.contentKeypressHandler(e.nativeEvent.code, index, e)}
+                      {...snippet}
+                    />
                   </section>
                 )
               })}


### PR DESCRIPTION
Implements the following changes

- when a user is focused on a tab header (shell/javascript), enter key should change focus to the tab content
- When a user is focused on a tab content (curl --), tab key should focus on the next available tab header (i.e. if you were inside of the shell tab content, it should focus on the javascript tab header.)
- When a user is focused on the final tab content, tab should resume normal tab order for the page.

# Demo

https://user-images.githubusercontent.com/40131297/186975170-74945543-f4ca-4172-8180-a48d4293317f.mov

